### PR TITLE
Get the right size in bytes from the old database (MySQL) to the new one (MongoDB)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 # Coveralls
 .coveralls.yml
 
+# PyCharm
+.idea/
 # C extensions
 *.so
 

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/bin/biomaj-migrate.py
+++ b/bin/biomaj-migrate.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import argparse
-import bitmath
+import humanfriendly
 import datetime
 import time
 import logging
@@ -16,23 +16,6 @@ from biomaj.bank import Bank
 from biomaj.config import BiomajConfig
 from biomaj.workflow import UpdateWorkflow, RemoveWorkflow, Workflow
 
-def convert_size(size):
-    """Convert old size from BioMAJ 1.2.x to size in bytes"""
-    supported_units = ['K', 'M', 'G', 'T', 'P']
-    pattern_size = re.compile("^([\d,]+)(\w)$")
-    relmatch = pattern_size.match(size)
-    if relmatch:
-        if relmatch.group(2) in supported_units:
-            size = relmatch.group(1)
-            unit = relmatch.group(2)
-            unit += 'iB'
-            size = size.replace(',', '.')
-            try:
-                new_size = bitmath.parse_string(size + ' ' + unit).to_Byte()
-                return float(new_size)
-            except ValueError as err:
-                raise Exception("Can't convert size: %s" % str(err))
-    return 0
 
 def migrate_bank(cur, bank, history=False):
     """
@@ -62,7 +45,7 @@ def migrate_bank(cur, bank, history=False):
             'session': row[1],
             'creation': row[2],
             'remove': row[3],
-            'size': convert_size(row[4]),
+            'size': humanfriendly.parse_size(row[4].replace(',', '.')),
             'release': row[5],
             'remoterelease': row[5],
             'logfile': row[6]

--- a/bin/biomaj-migrate.py
+++ b/bin/biomaj-migrate.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import argparse
+import bitmath
 import datetime
 import time
 import logging
@@ -15,6 +16,23 @@ from biomaj.bank import Bank
 from biomaj.config import BiomajConfig
 from biomaj.workflow import UpdateWorkflow, RemoveWorkflow, Workflow
 
+def convert_size(size):
+    """Convert old size from BioMAJ 1.2.x to size in bytes"""
+    supported_units = ['K', 'M', 'G', 'T', 'P']
+    pattern_size = re.compile("^([\d,]+)(\w)$")
+    relmatch = pattern_size.match(size)
+    if relmatch:
+        if relmatch.group(2) in supported_units:
+            size = relmatch.group(1)
+            unit = relmatch.group(2)
+            unit += 'iB'
+            size = size.replace(',', '.')
+            try:
+                new_size = bitmath.parse_string(size + ' ' + unit).to_Byte()
+                return float(new_size)
+            except ValueError as err:
+                raise Exception("Can't convert size: %s" % str(err))
+    return 0
 
 def migrate_bank(cur, bank, history=False):
     """
@@ -44,7 +62,7 @@ def migrate_bank(cur, bank, history=False):
             'session': row[1],
             'creation': row[2],
             'remove': row[3],
-            'size': row[4],
+            'size': convert_size(row[4]),
             'release': row[5],
             'remoterelease': row[5],
             'logfile': row[6]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ config = {
     'author_email': 'olivier.sallou@irisa.fr',
     'version': '3.0.2',
     'install_requires': ['nose',
-                         'bitmath',
+                         'humanfriendly',
                          'mysql-connector-python-rf',
                          'pymongo'],
     'packages': find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ config = {
     'author_email': 'olivier.sallou@irisa.fr',
     'version': '3.0.2',
     'install_requires': ['nose',
+                         'bitmath',
                          'mysql-connector-python-rf',
                          'pymongo'],
     'packages': find_packages(),


### PR DESCRIPTION
Hi,

I've discovered that during the migration, old size (e.g.: `1,12M, 34,567G`) are stored as it. However, in such case, static method biomaj.bank.get_bank_disc_usage fails with such values :-1: 
Thus this pull request should fix it. It however requires another lib to be installed (bitmath) set in setup.py.
Tested with `python 2.7 + pymongo (2.7.2 + 3.2.1)` and `python 3.4 and pymongo 2.7.2`.

Emmanuel
