### PR TITLE
Set correct time for field 'last_update_time' in database during migration

### DIFF
--- a/bin/biomaj-migrate.py
+++ b/bin/biomaj-migrate.py
@@ -100,10 +100,14 @@ def migrate_bank(cur, bank, history=False):
         # We set the session.id (timestamp) with creation field from productionDirectory table
         b.session.set('id', session_id)
         b.save_session()
+        # We need set update the field 'last_update_time' to the time the bank has been created
+        # because 'save_session' set this value to the time it is called
+        b.banks.update({'name': b.name, 'sessions.id': session_id},
+                       {'$set': {'sessions.$.last_update_time': session_id}})
         # Keep trace of the logfile. We need to do a manual update
         if prod['logfile'] and os.path.exists(prod['logfile']):
             b.banks.update({'name': b.name, 'sessions.id': session_id},
-                           {'$set': {"sessions.$.log_file": prod['logfile']}})
+                           {'$set': {'sessions.$.log_file': prod['logfile']}})
         # Due to the way save_session set also the production, to exclude last session
         # from the production entries, we need to loop over each production entries
         if history:


### PR DESCRIPTION
Hi,

I've noticed, that after a migration, all fields `last_update_time` have approximatively the same value.
Searching in code, I've found this is due to the way `biomaj.Bank.save_session` set this field.
Here is a small update to fix the problem.

Emmanuel
